### PR TITLE
feature/factory: Refactor use of PDO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "autoload": {
         "psr-4": {
+            "Anorm\\Test\\": "test/anorm/",
             "Anorm\\Tools\\": "tools/src/",
             "Anorm\\": "src/"
         }

--- a/src/Anorm.php
+++ b/src/Anorm.php
@@ -4,6 +4,8 @@ namespace Anorm;
 class Anorm
 {
 
+    const DEFAULT = 'default';
+
     private static $connections = array();
 
     /**
@@ -37,12 +39,26 @@ class Anorm
      * @return Anorm
      * @see connect
      */
-    public static function use($name)
+    public static function use($name = self::DEFAULT)
     {
         if (!\array_key_exists($name, self::$connections)) {
             throw new \Exception("Anorm: Connection '$name' doesn't exist. Call Anorm::connection first.");
         }
         return self::$connections[$name];
+    }
+
+    /**
+     * Returns the \PDO instance of the Anorm connection of the given $name
+     * @param string $name Name of the connection to use.
+     * @return \PDO
+     * @see connect
+     */
+    public static function pdo($name = self::DEFAULT)
+    {
+        if (!\array_key_exists($name, self::$connections)) {
+            throw new \Exception("Anorm: Connection '$name' doesn't exist. Call Anorm::connection first.");
+        }
+        return self::$connections[$name]->pdo;
     }
 
     /** @var \PDO The connection */

--- a/test/anorm/Anorm_Test.php
+++ b/test/anorm/Anorm_Test.php
@@ -28,6 +28,15 @@ class AnormTest extends TestCase
     }
 
     /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Anorm: Connection 'bogusname' doesn't exist. Call Anorm::connection first.
+     */
+    public function testPdo_NotConnected_Fails()
+    {
+        $result = Anorm::pdo('bogusname');
+    }
+
+    /**
      * @expectedException \PDOException
      * @expectedExceptionMessage SQLSTATE[HY000] [1045] Access denied for user 'bogus'@'localhost' (using password: NO)
      */

--- a/test/anorm/DataMapper_CrudEscape_Test.php
+++ b/test/anorm/DataMapper_CrudEscape_Test.php
@@ -2,23 +2,17 @@
 
 require_once(__DIR__ . '/../../vendor/autoload.php');
 
-require_once(__DIR__ . '/SomeTableModel.php');
-require_once(__DIR__ . '/TestEnvironment.php');
-
 use PHPUnit\Framework\TestCase;
 
-use Anorm\DataMapper;
-use Anorm\Model;
+use Anorm\Test\SomeTableModel;
+use Anorm\Test\TestEnvironment;
 
 class DataMapperCrudEscapeTest extends TestCase
 {
-    /** @var \PDO */
-    private $pdo;
-
     public function __construct()
     {
         parent::__construct();
-        $this->pdo = TestEnvironment::pdo();
+        TestEnvironment::connect();
     }
     
     public static function setUpBeforeClass()
@@ -31,8 +25,7 @@ class DataMapperCrudEscapeTest extends TestCase
 
     public function testCrud_OK()
     {
-        $model0 = new SomeTableModel($this->pdo);
-        $this->assertEquals($this->pdo, $model0->_mapper->pdo);
+        $model0 = new SomeTableModel();
         // Count current rows
         $n0 = $model0->countRows();
         $this->assertEquals(0, $n0);
@@ -49,7 +42,7 @@ class DataMapperCrudEscapeTest extends TestCase
         $this->assertEquals($n0 + 1, $n1);
 
         // Read (data present)
-        $model1 = new SomeTableModel($this->pdo);
+        $model1 = new SomeTableModel();
         $model1->read($model0->someId);
         $this->assertEquals($model0->name, $model1->name);
         $this->assertEquals($model0->dtc, $model1->dtc);
@@ -59,7 +52,7 @@ class DataMapperCrudEscapeTest extends TestCase
         $model1->write();
 
         // Read (data changed)
-        $model2 = new SomeTableModel($this->pdo);
+        $model2 = new SomeTableModel();
         $model2->read($model1->someId);
         $this->assertEquals($model1->name, $model2->name);
 

--- a/test/anorm/DataMapper_Find_Test.php
+++ b/test/anorm/DataMapper_Find_Test.php
@@ -2,13 +2,11 @@
 
 require_once(__DIR__ . '/../../vendor/autoload.php');
 
-require_once(__DIR__ . '/SomeTableModel.php');
-require_once(__DIR__ . '/TestEnvironment.php');
-
 use PHPUnit\Framework\TestCase;
 
 use Anorm\DataMapper;
-use Anorm\Model;
+use Anorm\Test\SomeTableModel;
+use Anorm\Test\TestEnvironment;
 
 class DataMapperFindTest extends TestCase
 {
@@ -40,7 +38,7 @@ class DataMapperFindTest extends TestCase
     // public function testFindOne_OK()
     // {
     //     /** @var SomeTableModel */
-    //     $model = DataMapper::find('SomeTableModel', $this->pdo)
+    //     $model = DataMapper::find(SomeTableModel::class, $this->pdo)
     //         ->where("`name`='Name 1'")
     //         ->one();
     //     $this->assertEquals('Name 1', $model->name);
@@ -49,7 +47,7 @@ class DataMapperFindTest extends TestCase
     public function testFindOne_OK()
     {
         /** @var SomeTableModel */
-        $model = DataMapper::find('SomeTableModel', $this->pdo)
+        $model = DataMapper::find(SomeTableModel::class, $this->pdo)
             ->where("`name`=:name", [':name' => 'Name 1'])
             ->one();
         $this->assertEquals('Name 1', $model->name);
@@ -58,7 +56,7 @@ class DataMapperFindTest extends TestCase
     public function testFindOneOrThrow_OK()
     {
         /** @var SomeTableModel */
-        $model = DataMapper::find('SomeTableModel', $this->pdo)
+        $model = DataMapper::find(SomeTableModel::class, $this->pdo)
         ->where("`name`=:name", [':name' => 'Name 1'])
         ->oneOrThrow();
         $this->assertEquals('Name 1', $model->name);
@@ -66,7 +64,7 @@ class DataMapperFindTest extends TestCase
 
     public function testFindSome_OK()
     {
-        $generator = DataMapper::find('SomeTableModel', $this->pdo)
+        $generator = DataMapper::find(SomeTableModel::class, $this->pdo)
             ->orderBy("name")
             ->limit(3)
             ->some();
@@ -81,7 +79,7 @@ class DataMapperFindTest extends TestCase
     public function testFindOne_NotPresent_False()
     {
         /** @var SomeTableModel */
-        $model = DataMapper::find('SomeTableModel', $this->pdo)
+        $model = DataMapper::find(SomeTableModel::class, $this->pdo)
             ->where("`name`=:name", [':name' => 'Bogus Name'])
             ->one();
         $this->assertEquals(false, $model);
@@ -94,7 +92,7 @@ class DataMapperFindTest extends TestCase
     public function testFindOneOrThrow_NotPresent_Throws()
     {
         /** @var SomeTableModel */
-        $model = DataMapper::find('SomeTableModel', $this->pdo)
+        $model = DataMapper::find(SomeTableModel::class, $this->pdo)
             ->where("`name`=:name", [':name' => 'Bogus Name'])
             ->oneOrThrow();
     }

--- a/test/anorm/DataMapper_Replace_Test.php
+++ b/test/anorm/DataMapper_Replace_Test.php
@@ -5,21 +5,20 @@ require_once(__DIR__ . '/../../vendor/autoload.php');
 require_once(__DIR__ . '/ReplaceTableModel.php');
 
 use PHPUnit\Framework\TestCase;
+use Anorm\Test\ReplaceTableModel;
+use Anorm\Test\TestEnvironment;
 
 class DataMapperReplaceTest extends TestCase
 {
-    /** @var \PDO */
-    private $pdo;
-
     public function __construct()
     {
         parent::__construct();
-        $this->pdo = new \PDO('mysql:host=localhost;dbname=anorm_test', 'travis', '');
+        TestEnvironment::connect();
     }
     
     public static function setUpBeforeClass()
     {
-        $pdo = new \PDO('mysql:host=localhost;dbname=anorm_test', 'travis', '');
+        $pdo = TestEnvironment::pdo();
         $pdo->query('DROP TABLE IF EXISTS `replace_table`');
         $sql = file_get_contents(__DIR__ . '/TestReplaceSchema.sql');
         $pdo->query($sql);
@@ -27,8 +26,7 @@ class DataMapperReplaceTest extends TestCase
 
     public function testReplace_OK()
     {
-        $model0 = new ReplaceTableModel($this->pdo);
-        $this->assertEquals($this->pdo, $model0->_mapper->pdo);
+        $model0 = new ReplaceTableModel();
         // Count current rows
         $n0 = $model0->countRows();
         $this->assertEquals(0, $n0);
@@ -43,7 +41,7 @@ class DataMapperReplaceTest extends TestCase
         $this->assertEquals($n0 + 1, $n1);
 
         // Read (data present)
-        $model1 = new ReplaceTableModel($this->pdo);
+        $model1 = new ReplaceTableModel();
         $model1->read($model0->replaceId);
         $this->assertEquals($model0->name, $model1->name);
 
@@ -52,7 +50,7 @@ class DataMapperReplaceTest extends TestCase
         $model1->write();
 
         // Read (data changed)
-        $model2 = new ReplaceTableModel($this->pdo);
+        $model2 = new ReplaceTableModel();
         $model2->read($model1->replaceId);
         $this->assertEquals($model1->name, $model2->name);
 
@@ -71,7 +69,7 @@ class DataMapperReplaceTest extends TestCase
      */
     public function testNoPrimaryKey_Throws()
     {
-        $model = new ReplaceTableModel($this->pdo);
+        $model = new ReplaceTableModel();
         $model->write();
     }
 }

--- a/test/anorm/DataMapper_Test.php
+++ b/test/anorm/DataMapper_Test.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 use Anorm\DataMapper;
 
-
 class TestClassModel {
     public $testProperty;
 }

--- a/test/anorm/QueryBuilder_Test.php
+++ b/test/anorm/QueryBuilder_Test.php
@@ -5,8 +5,8 @@ require_once(__DIR__ . '/../../vendor/autoload.php');
 use PHPUnit\Framework\TestCase;
 
 use Anorm\QueryBuilder;
-
-require_once(__DIR__ . '/TestEnvironment.php');
+use Anorm\Test\SomeTableModel;
+use Anorm\Test\TestEnvironment;
 
 class QueryBuilderTest extends TestCase
 {
@@ -22,7 +22,7 @@ class QueryBuilderTest extends TestCase
     public function testFunctions_ReturnThis()
     {
         $pdo = TestEnvironment::pdo();
-        $o = new QueryBuilder('SomeTableModel', $pdo);
+        $o = new QueryBuilder(SomeTableModel::class, $pdo);
         $result = $o->select('');
         $this->assertSame($o, $result);
         $result = $o->from('');

--- a/test/anorm/ReplaceTableModel.php
+++ b/test/anorm/ReplaceTableModel.php
@@ -1,11 +1,14 @@
 <?php
+namespace Anorm\Test;
 
+use Anorm\Anorm;
 use Anorm\DataMapper;
 use Anorm\Model;
 
 class ReplaceTableModel extends Model {
-    public function __construct(\PDO $pdo)
+    public function __construct()
     {
+        $pdo = Anorm::pdo();
         parent::__construct($pdo, DataMapper::createByClass($pdo, $this));
         $this->_mapper->modelPrimaryKey = 'replaceId';
         $this->_mapper->useReplace = true;

--- a/test/anorm/SomeTableModel.php
+++ b/test/anorm/SomeTableModel.php
@@ -1,11 +1,14 @@
 <?php
+namespace Anorm\Test;
 
+use Anorm\Anorm;
 use Anorm\DataMapper;
 use Anorm\Model;
 
 class SomeTableModel extends Model {
-    public function __construct(\PDO $pdo)
+    public function __construct()
     {
+        $pdo = Anorm::pdo();
         parent::__construct($pdo, DataMapper::createByClass($pdo, $this));
         $this->_mapper->modelPrimaryKey = 'someId';
         $this->dtc = null;

--- a/test/anorm/TestEnvironment.php
+++ b/test/anorm/TestEnvironment.php
@@ -1,13 +1,21 @@
 <?php
+namespace Anorm\Test;
 
+use Anorm\Anorm;
 class TestEnvironment
 {
+
+    public static function connect()
+    {
+        Anorm::connect(Anorm::DEFAULT, 'mysql:host=localhost;dbname=anorm_test', 'travis', '');
+    }
 
     public static function pdo() : \PDO
     {
         static $pdo = null;
         if (!$pdo) {
-            $pdo = new \PDO('mysql:host=localhost;dbname=anorm_test', 'travis', '');
+            self::connect();
+            $pdo = Anorm::pdo(Anorm::DEFAULT);
         }
         return $pdo;
     }


### PR DESCRIPTION
- Refactor use of PDO $pdo in Model so that it is not
  required in the constructor.

Models are now oppinionated as to their data source.
They know what connection their data comes from and
can therefore get the correct pdo from Anorm::pdo.