### PR TITLE
feat(lifecycle): allow listeners to call write() without re-invocation

### DIFF
--- a/docs/_docs/lifecycle.md
+++ b/docs/_docs/lifecycle.md
@@ -91,21 +91,17 @@ incorrect for change tracking.
 
 ## Re-entrancy
 
-A listener must not call `DataMapper::write()` synchronously, because the
-recursive write would itself fire the listener. Doing so raises
-`Anorm\Lifecycle\ReentrantWriteException`, surfaced to the caller of the
-outer `write()`. The snapshot is still refreshed before the exception
-propagates, so the caller's view of `$_lastSnapshot` reflects the committed
-state.
-
-If the listener needs to persist follow-up records, queue them in memory and
-flush at the end of the request (e.g. via a middleware after-handler).
+A listener may call `DataMapper::write()` — for example, to persist a
+follow-up record on a different table in response to a change. Nested writes
+commit their SQL and refresh their own `$_lastSnapshot`, but do **not**
+re-invoke the listener. Anorm assumes a single in-flight listener and
+suppresses recursive notifications for any depth.
 
 ## Listener exceptions
 
-Anorm wraps the listener call in `try/catch`. Any exception other than
-`ReentrantWriteException` is logged via `error_log` and swallowed; the write
-itself succeeds. Listener faults must never break writes.
+Anorm wraps the listener call in `try/catch`. Any exception thrown by the
+listener is logged via `error_log` and swallowed; the write itself succeeds.
+Listener faults must never break writes.
 
 If you want strict behaviour, your listener can catch and re-throw a wrapper
 type — but most consumers prefer fire-and-forget.

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -146,15 +146,10 @@ class DataMapper
 
     public function write(&$c)
     {
-        if (self::$insideListener) {
-            throw new \Anorm\Lifecycle\ReentrantWriteException(
-                'DataMapper::write() called inside a ChangeListener. Defer the write until after the listener returns.'
-            );
-        }
-
-        $hasListener = (self::$changeListener !== null);
-        $isInsert    = $hasListener && ($c->_lastSnapshot === null);
-        $snapshot    = $hasListener ? $c->_lastSnapshot : null;
+        $hasListener  = (self::$changeListener !== null);
+        $shouldNotify = $hasListener && !self::$insideListener;
+        $isInsert     = $hasListener && ($c->_lastSnapshot === null);
+        $snapshot     = $hasListener ? $c->_lastSnapshot : null;
 
         $key = $this->modelPrimaryKey;
         if ($this->useReplace) {
@@ -232,20 +227,19 @@ class DataMapper
             }
         }
 
-        if ($hasListener) {
+        if ($shouldNotify) {
             $diff = $isInsert ? [] : $this->diff($snapshot, $c);
             self::$insideListener = true;
             try {
                 self::$changeListener->onWrite($c, $diff, $isInsert);
-            } catch (\Anorm\Lifecycle\ReentrantWriteException $e) {
-                $c->_lastSnapshot = $this->captureSnapshot($c);
-                throw $e;
             } catch (\Throwable $e) {
                 error_log('Anorm change listener threw: ' . $e->getMessage());
             } finally {
                 self::$insideListener = false;
             }
+        }
 
+        if ($hasListener) {
             $c->_lastSnapshot = $this->captureSnapshot($c);
         }
 

--- a/src/Lifecycle/ReentrantWriteException.php
+++ b/src/Lifecycle/ReentrantWriteException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Anorm\Lifecycle;
-
-class ReentrantWriteException extends \RuntimeException
-{
-}

--- a/test/anorm/Lifecycle/ChangeListenerTest.php
+++ b/test/anorm/Lifecycle/ChangeListenerTest.php
@@ -203,6 +203,52 @@ class ChangeListenerTest extends TestCase
         $this->assertArrayHasKey('payload', $diff);
     }
 
+    public function testDiff_NullToValue_DetectsChange()
+    {
+        $m = new LifecycleModel();
+        $m->name = 'alice';
+        $m->email = 'a@example.com';
+        $snapshot = ['name' => 'alice', 'email' => null, 'dtu' => null, 'payload' => null];
+        $diff = $m->_mapper->diff($snapshot, $m);
+        $this->assertSame(['email' => ['from' => null, 'to' => 'a@example.com']], $diff);
+    }
+
+    public function testDiff_ValueToNull_DetectsChange()
+    {
+        $m = new LifecycleModel();
+        $m->name = 'alice';
+        $m->email = null;
+        $snapshot = ['name' => 'alice', 'email' => 'a@example.com', 'dtu' => null, 'payload' => null];
+        $diff = $m->_mapper->diff($snapshot, $m);
+        $this->assertSame(['email' => ['from' => 'a@example.com', 'to' => null]], $diff);
+    }
+
+    public function testDiff_ArrayEquality_NoChange()
+    {
+        $m = new LifecycleModel();
+        $m->name = 'alice';
+        $m->payload = ['a', 'b', 'c'];
+        $snapshot = [
+            'name' => 'alice', 'email' => null, 'dtu' => null,
+            'payload' => ['a', 'b', 'c'],
+        ];
+        $diff = $m->_mapper->diff($snapshot, $m);
+        $this->assertArrayNotHasKey('payload', $diff);
+    }
+
+    public function testDiff_ArrayEquality_DetectsDifference()
+    {
+        $m = new LifecycleModel();
+        $m->name = 'alice';
+        $m->payload = ['a', 'b', 'c'];
+        $snapshot = [
+            'name' => 'alice', 'email' => null, 'dtu' => null,
+            'payload' => ['a', 'b'],
+        ];
+        $diff = $m->_mapper->diff($snapshot, $m);
+        $this->assertArrayHasKey('payload', $diff);
+    }
+
     public function testDiff_ObjectEquality_DifferentClasses()
     {
         $m = new LifecycleModel();
@@ -388,6 +434,67 @@ class ChangeListenerTest extends TestCase
             ->query('SELECT name FROM `lifecycle_model` ORDER BY id')
             ->fetchAll(\PDO::FETCH_COLUMN);
         $this->assertSame(['alice', 'side-effect'], $rows);
+    }
+
+    public function testWrite_ListenerThrows_SubsequentWriteStillFiresListener()
+    {
+        $listener = new class implements ChangeListenerInterface {
+            public $callCount = 0;
+            public function onWrite(\Anorm\Model $model, array $diff, bool $isInsert): void
+            {
+                $this->callCount++;
+                throw new \RuntimeException('boom');
+            }
+        };
+        DataMapper::setChangeListener($listener);
+
+        $tmp = tempnam(sys_get_temp_dir(), 'anorm_err_');
+        $prev = ini_set('error_log', $tmp);
+        try {
+            $a = new LifecycleModel();
+            $a->name = 'alice';
+            $a->write();
+
+            $b = new LifecycleModel();
+            $b->name = 'bob';
+            $b->write();
+        } finally {
+            ini_set('error_log', $prev);
+        }
+
+        // Both writes must fire the listener — the finally block resets
+        // $insideListener after the first throw.
+        $this->assertSame(2, $listener->callCount);
+        unlink($tmp);
+    }
+
+    public function testWrite_AfterNestedWrite_OuterContinuesNormally()
+    {
+        $listener = new class implements ChangeListenerInterface {
+            public $callCount = 0;
+            public function onWrite(\Anorm\Model $model, array $diff, bool $isInsert): void
+            {
+                $this->callCount++;
+                if ($this->callCount === 1) {
+                    $other = new LifecycleModel();
+                    $other->name = 'side-effect';
+                    $other->write();
+                }
+            }
+        };
+        DataMapper::setChangeListener($listener);
+
+        $a = new LifecycleModel();
+        $a->name = 'alice';
+        $a->write();
+
+        // After the nested-write call returns, $insideListener must be reset
+        // so a subsequent top-level write fires the listener again.
+        $b = new LifecycleModel();
+        $b->name = 'bob';
+        $b->write();
+
+        $this->assertSame(2, $listener->callCount);
     }
 
     public function testWrite_PartialLoad_DiffOnlyHasLoadedFields()

--- a/test/anorm/Lifecycle/ChangeListenerTest.php
+++ b/test/anorm/Lifecycle/ChangeListenerTest.php
@@ -332,51 +332,62 @@ class ChangeListenerTest extends TestCase
         unlink($tmp);
     }
 
-    public function testWrite_ListenerCallsWrite_ThrowsReentrantWriteException()
+    public function testWrite_ListenerCallsWrite_NestedWriteCommits()
     {
-        $reentrant = new class implements ChangeListenerInterface {
+        $listener = new class implements ChangeListenerInterface {
+            /** @var LifecycleModel|null */
+            public $captured = null;
             public function onWrite(\Anorm\Model $model, array $diff, bool $isInsert): void
             {
                 $other = new LifecycleModel();
                 $other->name = 'side-effect';
                 $other->write();
+                $this->captured = $other;
             }
         };
-        DataMapper::setChangeListener($reentrant);
+        DataMapper::setChangeListener($listener);
 
         $m = new LifecycleModel();
         $m->name = 'alice';
-
-        $this->expectException(\Anorm\Lifecycle\ReentrantWriteException::class);
         $m->write();
+
+        $this->assertNotNull($m->id);
+        $this->assertNotNull($listener->captured);
+        $this->assertNotNull($listener->captured->id);
+        $this->assertNotSame($m->id, $listener->captured->id);
+
+        // Nested write must still refresh its own snapshot, since the listener
+        // is registered. The listener simply isn't re-invoked for it.
+        $this->assertIsArray($listener->captured->_lastSnapshot);
+        $this->assertSame('side-effect', $listener->captured->_lastSnapshot['name']);
     }
 
-    public function testWrite_ReentrantException_StillRefreshesSnapshot()
+    public function testWrite_NestedWrite_DoesNotReinvokeListener()
     {
-        $reentrant = new class implements ChangeListenerInterface {
+        $listener = new class implements ChangeListenerInterface {
+            public $callCount = 0;
             public function onWrite(\Anorm\Model $model, array $diff, bool $isInsert): void
             {
-                $other = new LifecycleModel();
-                $other->name = 'side-effect';
-                $other->write();
+                $this->callCount++;
+                if ($this->callCount === 1) {
+                    $other = new LifecycleModel();
+                    $other->name = 'side-effect';
+                    $other->write();
+                }
             }
         };
-        DataMapper::setChangeListener($reentrant);
+        DataMapper::setChangeListener($listener);
 
         $m = new LifecycleModel();
         $m->name = 'alice';
-        try {
-            $m->write();
-            $this->fail('Expected ReentrantWriteException');
-        } catch (\Anorm\Lifecycle\ReentrantWriteException $e) {
-            // expected
-        }
+        $m->write();
 
-        // Even though the exception propagated, the SQL committed, so the snapshot
-        // must reflect post-write state.
-        $this->assertIsArray($m->_lastSnapshot);
-        $this->assertSame('alice', $m->_lastSnapshot['name']);
-        $this->assertNotNull($m->id);
+        $this->assertSame(1, $listener->callCount);
+
+        $rows = TestEnvironment::pdo()
+            ->query('SELECT name FROM `lifecycle_model` ORDER BY id')
+            ->fetchAll(\PDO::FETCH_COLUMN);
+        $this->assertSame(['alice', 'side-effect'], $rows);
     }
 
     public function testWrite_PartialLoad_DiffOnlyHasLoadedFields()


### PR DESCRIPTION
## Summary
- A `ChangeListener` may now call `DataMapper::write()` — typically to persist a follow-up record on a different table in response to a change. Nested writes commit and refresh their own `$_lastSnapshot`, but do not re-invoke the listener.
- Anorm assumes a single in-flight listener and suppresses recursive notifications at any depth (gate: `$shouldNotify = $hasListener && !$insideListener`).
- Removes `Anorm\Lifecycle\ReentrantWriteException` outright. 3.1.x is not yet released, so this lands in 3.1.1 with no BC carve-out.

## Why
The original guard blocked the common "react to change by writing elsewhere" pattern (e.g. audit row, derived projection). The user confirmed only one listener is ever registered, so depth-1 suppression of recursive dispatch is sufficient — no need to throw.

## Files
- `src/DataMapper.php` — drops top-of-method throw; gates `onWrite()` on `$shouldNotify`; snapshot still refreshes whenever a listener is registered.
- `src/Lifecycle/ReentrantWriteException.php` — deleted.
- `test/anorm/Lifecycle/ChangeListenerTest.php` — replaces the two re-entrancy tests with `testWrite_ListenerCallsWrite_NestedWriteCommits` and `testWrite_NestedWrite_DoesNotReinvokeListener`.
- `docs/_docs/lifecycle.md` — rewrites the "Re-entrancy" section; removes the queue-and-flush workaround and the `ReentrantWriteException` carve-out from "Listener exceptions".

## Test plan
- [x] `composer test` — 351 tests pass (1 pre-existing skip)
- [x] `composer cs:check` — clean
- [x] `composer analyze` (phpstan level 5) — clean
- [x] New tests assert nested write commits AND listener fires exactly once
- [x] Nested model's `$_lastSnapshot` still refreshes (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)