### PR TITLE
chore: improve test coverage for TableMaker, QueryBuilder, and Model

### DIFF
--- a/src/TableMaker.php
+++ b/src/TableMaker.php
@@ -159,7 +159,7 @@ class TableMaker
     {
         $type = $relationship->getType();
 
-        if ($type === 'ManyHasOne') {
+        if ($type === 'manyHasOne') {
             // For belongsTo relationships, create foreign key on current table
             $this->createForeignKey(
                 $this->mapper->table,
@@ -168,7 +168,7 @@ class TableMaker
                 $relationship->getPrimaryKey(),
                 $relationship->getConstraintOptions()
             );
-        } elseif ($type === 'OneHasMany') {
+        } elseif ($type === 'oneHasMany') {
             // For hasMany relationships, create foreign key on related table
             $this->createForeignKey(
                 $this->getTableNameFromModelClass($relationship->getRelatedModelClass()),
@@ -196,7 +196,8 @@ class TableMaker
             return;
         }
 
-        // Ensure the referenced table exists
+        // Ensure both tables exist
+        $this->ensureTableExists($table);
         $this->ensureTableExists($referencedTable);
 
         // Ensure the column exists in the source table

--- a/test/anorm/Model_ConvenienceMethods_Test.php
+++ b/test/anorm/Model_ConvenienceMethods_Test.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Anorm\Test;
+
+require_once(__DIR__ . '/../../vendor/autoload.php');
+
+use Anorm\DataMapper;
+use Anorm\Model;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exposes protected convenience methods for direct testing.
+ */
+class ExposedModel extends UserModel
+{
+    public function publicSetNullDelete(): array
+    {
+        return $this->setNullDelete();
+    }
+
+    public function publicRestrictDelete(): array
+    {
+        return $this->restrictDelete();
+    }
+
+    public function publicConstraintOptions(
+        string $onDelete = 'RESTRICT',
+        string $onUpdate = 'CASCADE',
+        ?string $constraintName = null
+    ): array {
+        return $this->constraintOptions($onDelete, $onUpdate, $constraintName);
+    }
+}
+
+/**
+ * Model that uses hasMany/belongsTo/hasManyThrough WITHOUT explicit property names.
+ * Auto-generated names: 'posts' (hasMany PostModel), 'company' (belongsTo CompanyModel),
+ * 'tags' (hasManyThrough TagModel).
+ */
+class AutoNameModel extends Model
+{
+    public $id;
+    public $company_id;
+
+    public function __construct(\PDO $pdo)
+    {
+        $mapper = DataMapper::createByClass($pdo, $this);
+        $mapper->table = 'users';
+        parent::__construct($pdo, $mapper);
+
+        // No $propertyName argument -> triggers getPropertyNameFromClass()
+        $this->hasMany(PostModel::class, 'user_id');
+        $this->belongsTo(CompanyModel::class, 'company_id');
+        $this->hasManyThrough(TagModel::class, 'post_id', 'tag_id', 'post_tags');
+    }
+}
+
+class Model_ConvenienceMethods_Test extends TestCase
+{
+    /** @var \PDO */
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = TestEnvironment::pdo();
+    }
+
+    // -----------------------------------------------------------------
+    // setNullDelete / restrictDelete / constraintOptions
+    // -----------------------------------------------------------------
+
+    public function testSetNullDelete_ReturnsCorrectOptions()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicSetNullDelete();
+        $this->assertEquals([
+            'constraints' => [
+                'on_delete' => 'SET NULL',
+                'on_update' => 'CASCADE',
+            ]
+        ], $result);
+    }
+
+    public function testRestrictDelete_ReturnsCorrectOptions()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicRestrictDelete();
+        $this->assertEquals([
+            'constraints' => [
+                'on_delete' => 'RESTRICT',
+                'on_update' => 'CASCADE',
+            ]
+        ], $result);
+    }
+
+    public function testConstraintOptions_DefaultValues()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicConstraintOptions();
+        $this->assertEquals([
+            'constraints' => [
+                'on_delete' => 'RESTRICT',
+                'on_update' => 'CASCADE',
+            ]
+        ], $result);
+    }
+
+    public function testConstraintOptions_CustomValues()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicConstraintOptions('CASCADE', 'RESTRICT', 'my_constraint');
+        $this->assertEquals([
+            'constraints' => [
+                'on_delete' => 'CASCADE',
+                'on_update' => 'RESTRICT',
+                'constraint_name' => 'my_constraint',
+            ]
+        ], $result);
+    }
+
+    public function testConstraintOptions_WithConstraintName_IncludesName()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicConstraintOptions('SET NULL', 'CASCADE', 'fk_custom');
+        $this->assertArrayHasKey('constraint_name', $result['constraints']);
+        $this->assertEquals('fk_custom', $result['constraints']['constraint_name']);
+    }
+
+    // -----------------------------------------------------------------
+    // Auto-generated property names via hasMany / belongsTo / hasManyThrough
+    // -----------------------------------------------------------------
+
+    public function testHasMany_NoPropertyName_AutoGeneratesPluralName()
+    {
+        $model = new AutoNameModel($this->pdo);
+        $manager = $model->getRelationshipManager();
+
+        $rel = $manager->getRelationship('posts');
+        $this->assertNotNull($rel, "Expected auto-generated relationship name 'posts'");
+        $this->assertEquals('Anorm\Test\PostModel', $rel->getRelatedModelClass());
+    }
+
+    public function testBelongsTo_NoPropertyName_AutoGeneratesSingularName()
+    {
+        $model = new AutoNameModel($this->pdo);
+        $manager = $model->getRelationshipManager();
+
+        $rel = $manager->getRelationship('company');
+        $this->assertNotNull($rel, "Expected auto-generated relationship name 'company'");
+        $this->assertEquals('Anorm\Test\CompanyModel', $rel->getRelatedModelClass());
+    }
+
+    public function testHasManyThrough_NoPropertyName_AutoGeneratesPluralName()
+    {
+        $model = new AutoNameModel($this->pdo);
+        $manager = $model->getRelationshipManager();
+
+        $rel = $manager->getRelationship('tags');
+        $this->assertNotNull($rel, "Expected auto-generated relationship name 'tags'");
+        $this->assertEquals('Anorm\Test\TagModel', $rel->getRelatedModelClass());
+    }
+
+    // -----------------------------------------------------------------
+    // createForeignKeyConstraints() early-return (non-dynamic mode)
+    // -----------------------------------------------------------------
+
+    public function testCreateForeignKeyConstraints_NonDynamicMode_DoesNothing()
+    {
+        $user = new UserModel($this->pdo);
+        // UserModel uses the default mode (not MODE_DYNAMIC), so calling
+        // createForeignKeyConstraints() should hit the early-return branch.
+        $user->createForeignKeyConstraints();
+        $this->assertTrue(true);
+    }
+}

--- a/test/anorm/Model_ConvenienceMethods_Test.php
+++ b/test/anorm/Model_ConvenienceMethods_Test.php
@@ -30,6 +30,11 @@ class ExposedModel extends UserModel
     ): array {
         return $this->constraintOptions($onDelete, $onUpdate, $constraintName);
     }
+
+    public function publicCascadeDelete(): array
+    {
+        return $this->cascadeDelete();
+    }
 }
 
 /**
@@ -85,18 +90,6 @@ class Model_ConvenienceMethods_Test extends TestCase
     {
         $model = new ExposedModel($this->pdo);
         $result = $model->publicRestrictDelete();
-        $this->assertEquals([
-            'constraints' => [
-                'on_delete' => 'RESTRICT',
-                'on_update' => 'CASCADE',
-            ]
-        ], $result);
-    }
-
-    public function testConstraintOptions_DefaultValues()
-    {
-        $model = new ExposedModel($this->pdo);
-        $result = $model->publicConstraintOptions();
         $this->assertEquals([
             'constraints' => [
                 'on_delete' => 'RESTRICT',
@@ -164,12 +157,24 @@ class Model_ConvenienceMethods_Test extends TestCase
     // createForeignKeyConstraints() early-return (non-dynamic mode)
     // -----------------------------------------------------------------
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCreateForeignKeyConstraints_NonDynamicMode_DoesNothing()
     {
         $user = new UserModel($this->pdo);
-        // UserModel uses the default mode (not MODE_DYNAMIC), so calling
-        // createForeignKeyConstraints() should hit the early-return branch.
         $user->createForeignKeyConstraints();
-        $this->assertTrue(true);
+    }
+
+    public function testCascadeDelete_ReturnsCorrectOptions()
+    {
+        $model = new ExposedModel($this->pdo);
+        $result = $model->publicCascadeDelete();
+        $this->assertEquals([
+            'constraints' => [
+                'on_delete' => 'CASCADE',
+                'on_update' => 'CASCADE',
+            ]
+        ], $result);
     }
 }

--- a/test/anorm/QueryBuilder_Test.php
+++ b/test/anorm/QueryBuilder_Test.php
@@ -7,9 +7,24 @@ use PHPUnit\Framework\TestCase;
 use Anorm\QueryBuilder;
 use Anorm\Test\SomeTableModel;
 use Anorm\Test\TestEnvironment;
+use Anorm\Test\UserModel;
+use Anorm\Relationship\Performance\PerformanceMonitor;
 
-class QueryBuilderTest extends TestCase
+class QueryBuilder_Test extends TestCase
 {
+    private $pdo;
+
+    public static function setUpBeforeClass(): void
+    {
+        TestEnvironment::connect();
+        TestEnvironment::loadRelationshipSchema();
+    }
+
+    protected function setUp(): void
+    {
+        $this->pdo = TestEnvironment::pdo();
+    }
+
     public function testConstruct_BogusClass_Throws()
     {
         $this->expectException(\Exception::class);
@@ -38,5 +53,87 @@ class QueryBuilderTest extends TestCase
         $this->assertSame($o, $result);
         $result = $o->limit('');
         $this->assertSame($o, $result);
+    }
+
+    public function testWith_StringInput_ConvertsToArray()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $result = $qb->with('posts'); // string, not array
+        $this->assertSame($qb, $result);
+    }
+
+    public function testWith_InvalidSpec_CircularRef_ThrowsInvalidArgumentException()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $this->expectException(\InvalidArgumentException::class);
+        $qb->with(['posts.posts']); // 'posts' appears twice → circular reference error
+    }
+
+    public function testWith_EmptyString_ThrowsInvalidArgumentException()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $this->expectException(\InvalidArgumentException::class);
+        $qb->with(['']);
+    }
+
+    public function testJoinRelationship_UndefinedRelationship_Throws()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Relationship 'nonexistent' not defined");
+        $qb->joinRelationship('nonexistent');
+    }
+
+    public function testJoinRelationship_ValidRelationship_ReturnsSelf()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $result = $qb->joinRelationship('posts');
+        $this->assertSame($qb, $result);
+    }
+
+    public function testJoinRelationship_CustomJoinType_ReturnsSelf()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $result = $qb->joinRelationship('posts', 'INNER');
+        $this->assertSame($qb, $result);
+    }
+
+    public function testSetBatchLoadingConfig_ReturnsSelf()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $result = $qb->setBatchLoadingConfig(['batch_size' => 100]);
+        $this->assertSame($qb, $result);
+    }
+
+    public function testSetPerformanceMonitor_ReturnsSelf()
+    {
+        $qb = new QueryBuilder(UserModel::class, $this->pdo);
+        $result = $qb->setPerformanceMonitor(new PerformanceMonitor());
+        $this->assertSame($qb, $result);
+    }
+
+    public function testSome_WithPerformanceMonitorAndEagerLoad_ReturnsModels()
+    {
+        $models = iterator_to_array(
+            (new QueryBuilder(UserModel::class, $this->pdo))
+                ->setPerformanceMonitor(new PerformanceMonitor())
+                ->with(['posts'])
+                ->some()
+        );
+
+        $this->assertNotEmpty($models);
+        $this->assertInstanceOf(UserModel::class, $models[0]);
+    }
+
+    public function testSome_WithNestedRelationships_LoadsWithoutException()
+    {
+        $models = iterator_to_array(
+            (new QueryBuilder(UserModel::class, $this->pdo))
+                ->with(['posts.comments'])
+                ->some()
+        );
+
+        $this->assertNotEmpty($models);
+        $this->assertInstanceOf(UserModel::class, $models[0]);
     }
 }

--- a/test/anorm/QueryBuilder_Test.php
+++ b/test/anorm/QueryBuilder_Test.php
@@ -35,7 +35,7 @@ class QueryBuilder_Test extends TestCase
 
     public function testFunctions_ReturnThis()
     {
-        $pdo = TestEnvironment::pdo();
+        $pdo = $this->pdo;
         $o = new QueryBuilder(SomeTableModel::class, $pdo);
         $result = $o->select('');
         $this->assertSame($o, $result);
@@ -123,6 +123,7 @@ class QueryBuilder_Test extends TestCase
 
         $this->assertNotEmpty($models);
         $this->assertInstanceOf(UserModel::class, $models[0]);
+        $this->assertIsArray($models[0]->posts);
     }
 
     public function testSome_WithNestedRelationships_LoadsWithoutException()
@@ -135,5 +136,6 @@ class QueryBuilder_Test extends TestCase
 
         $this->assertNotEmpty($models);
         $this->assertInstanceOf(UserModel::class, $models[0]);
+        $this->assertIsArray($models[0]->posts);
     }
 }

--- a/test/anorm/TableMaker_Test.php
+++ b/test/anorm/TableMaker_Test.php
@@ -39,6 +39,10 @@ class TableMakerTest extends TestCase
         $this->pdo = TestEnvironment::pdo();
     }
 
+    protected function tearDown(): void
+    {
+        $this->dropTmTables();
+    }
 
     public function testColumnDefinition_Integer_OK()
     {
@@ -181,8 +185,6 @@ class TableMakerTest extends TestCase
             $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
             'Expected FK constraint fk_tm_items_parent_id to be created on tm_items'
         );
-
-        $this->dropTmTables();
     }
 
     public function testFix_HY000_WithFkMessageAndModel_CreatesForeignKey()
@@ -207,8 +209,6 @@ class TableMakerTest extends TestCase
             $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
             'Expected FK constraint to be created via HY000 + FK message path'
         );
-
-        $this->dropTmTables();
     }
 
     public function testFix_ForeignKeyAlreadyExists_DoesNotDuplicate()
@@ -232,10 +232,17 @@ class TableMakerTest extends TestCase
             'Cannot add or update a child row: a foreign key constraint fails'
         );
 
+        // Should not throw even though FK already exists (idempotency guard in foreignKeyExists())
         TableMaker::fix($e, $child->_mapper, $child);
-        $this->assertTrue($this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'));
 
-        $this->dropTmTables();
+        // Confirm FK still exists and wasn't doubled up
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) AS cnt FROM information_schema.TABLE_CONSTRAINTS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tm_items'
+             AND CONSTRAINT_TYPE = 'FOREIGN KEY'"
+        );
+        $stmt->execute();
+        $this->assertEquals(1, (int) $stmt->fetch(\PDO::FETCH_ASSOC)['cnt'], 'Expected exactly one FK on tm_items');
     }
 
     public function testFix_HasManyRelationship_CreatesForeignKeyOnRelatedTable()
@@ -259,7 +266,5 @@ class TableMakerTest extends TestCase
             $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
             'Expected FK on tm_items (auto-created by ensureTableExists) referencing tm_parents'
         );
-
-        $this->dropTmTables();
     }
 }

--- a/test/anorm/TableMaker_Test.php
+++ b/test/anorm/TableMaker_Test.php
@@ -17,6 +17,15 @@ class TableMakerTestException extends \PDOException
     }
 }
 
+class TableMakerTestExceptionWithMessage extends \PDOException
+{
+    public function __construct(string $code, string $msg)
+    {
+        $this->code = $code;
+        $this->message = $msg;
+    }
+}
+
 class TableMakerTest extends TestCase
 {
     /** @var \PDO */
@@ -90,5 +99,37 @@ class TableMakerTest extends TestCase
         $e = new TableMakerTestException('42S22'); // Column does not exist
         $mapper = DataMapper::create($this->pdo, null, null);
         TableMaker::fix($e, $mapper);
+    }
+
+    public function testFix_23000_NoModel_DoesNotThrow()
+    {
+        $e = new TableMakerTestExceptionWithMessage(
+            '23000',
+            'Cannot add or update a child row: a foreign key constraint fails'
+        );
+        $mapper = DataMapper::create($this->pdo, null, null);
+        TableMaker::fix($e, $mapper, null);
+        $this->assertTrue(true);
+    }
+
+    public function testFix_HY000_WithForeignKeyMessage_DoesNotThrow()
+    {
+        $e = new TableMakerTestExceptionWithMessage(
+            'HY000',
+            'General error: 1215 Cannot add foreign key constraint'
+        );
+        $mapper = DataMapper::create($this->pdo, null, null);
+        TableMaker::fix($e, $mapper, null);
+        $this->assertTrue(true);
+    }
+
+    public function testFix_HY000_WithoutForeignKeyMessage_Rethrows()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage('Some unrelated general error');
+
+        $e = new TableMakerTestExceptionWithMessage('HY000', 'Some unrelated general error');
+        $mapper = DataMapper::create($this->pdo, null, null);
+        TableMaker::fix($e, $mapper, null);
     }
 }

--- a/test/anorm/TableMaker_Test.php
+++ b/test/anorm/TableMaker_Test.php
@@ -1,12 +1,15 @@
 <?php
 
 require_once(__DIR__ . '/../../vendor/autoload.php');
+require_once(__DIR__ . '/TmModels.php');
 
 use PHPUnit\Framework\TestCase;
 
 use Anorm\DataMapper;
 use Anorm\TableMaker;
 use Anorm\Test\TestEnvironment;
+use Anorm\Test\TmItemModel;
+use Anorm\Test\TmParentModel;
 
 class TableMakerTestException extends \PDOException
 {
@@ -135,5 +138,128 @@ class TableMakerTest extends TestCase
         $e = new TableMakerTestExceptionWithMessage('HY000', 'Some unrelated general error');
         $mapper = DataMapper::create($this->pdo, null, null);
         TableMaker::fix($e, $mapper, null);
+    }
+
+    private function dropTmTables(): void
+    {
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+        $this->pdo->exec('DROP TABLE IF EXISTS tm_items');
+        $this->pdo->exec('DROP TABLE IF EXISTS tm_parents');
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+    }
+
+    private function tmForeignKeyExists(string $table, string $constraint): bool
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) AS cnt FROM information_schema.TABLE_CONSTRAINTS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ? AND CONSTRAINT_NAME = ? AND CONSTRAINT_TYPE = 'FOREIGN KEY'"
+        );
+        $stmt->execute([$table, $constraint]);
+        return (bool) $stmt->fetch(\PDO::FETCH_ASSOC)['cnt'];
+    }
+
+    public function testFix_23000_WithBelongsToModel_CreatesForeignKey()
+    {
+        $this->dropTmTables();
+        $this->pdo->exec(
+            'CREATE TABLE tm_parents (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+        $this->pdo->exec(
+            'CREATE TABLE tm_items (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+
+        $child = new TmItemModel($this->pdo);
+        $e = new TableMakerTestExceptionWithMessage(
+            '23000',
+            'Cannot add or update a child row: a foreign key constraint fails'
+        );
+
+        TableMaker::fix($e, $child->_mapper, $child);
+
+        $this->assertTrue(
+            $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
+            'Expected FK constraint fk_tm_items_parent_id to be created on tm_items'
+        );
+
+        $this->dropTmTables();
+    }
+
+    public function testFix_HY000_WithFkMessageAndModel_CreatesForeignKey()
+    {
+        $this->dropTmTables();
+        $this->pdo->exec(
+            'CREATE TABLE tm_parents (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+        $this->pdo->exec(
+            'CREATE TABLE tm_items (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+
+        $child = new TmItemModel($this->pdo);
+        $e = new TableMakerTestExceptionWithMessage(
+            'HY000',
+            'General error: 1215 Cannot add foreign key constraint'
+        );
+
+        TableMaker::fix($e, $child->_mapper, $child);
+
+        $this->assertTrue(
+            $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
+            'Expected FK constraint to be created via HY000 + FK message path'
+        );
+
+        $this->dropTmTables();
+    }
+
+    public function testFix_ForeignKeyAlreadyExists_DoesNotDuplicate()
+    {
+        $this->dropTmTables();
+        $this->pdo->exec(
+            'CREATE TABLE tm_parents (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+        $this->pdo->exec(
+            'CREATE TABLE tm_items (
+                id INT(11) AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(128) NULL,
+                parent_id INT(11) NULL,
+                CONSTRAINT fk_tm_items_parent_id FOREIGN KEY (parent_id) REFERENCES tm_parents(id)
+             ) ENGINE=InnoDB'
+        );
+
+        $child = new TmItemModel($this->pdo);
+        $e = new TableMakerTestExceptionWithMessage(
+            '23000',
+            'Cannot add or update a child row: a foreign key constraint fails'
+        );
+
+        TableMaker::fix($e, $child->_mapper, $child);
+        $this->assertTrue($this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'));
+
+        $this->dropTmTables();
+    }
+
+    public function testFix_HasManyRelationship_CreatesForeignKeyOnRelatedTable()
+    {
+        $this->dropTmTables();
+        $this->pdo->exec(
+            'CREATE TABLE tm_parents (id INT(11) AUTO_INCREMENT PRIMARY KEY, name VARCHAR(128) NULL) ENGINE=InnoDB'
+        );
+
+        $parent = new TmParentModel($this->pdo);
+        $e = new TableMakerTestExceptionWithMessage(
+            '23000',
+            'Cannot add or update a child row: a foreign key constraint fails'
+        );
+
+        // The hasMany relationship on TmParentModel creates FK on tm_items referencing tm_parents.
+        // getTableNameFromModelClass('Anorm\Test\TmItemModel') must resolve to 'tm_items'.
+        TableMaker::fix($e, $parent->_mapper, $parent);
+
+        $this->assertTrue(
+            $this->tmForeignKeyExists('tm_items', 'fk_tm_items_parent_id'),
+            'Expected FK on tm_items (auto-created by ensureTableExists) referencing tm_parents'
+        );
+
+        $this->dropTmTables();
     }
 }

--- a/test/anorm/TableMaker_Test.php
+++ b/test/anorm/TableMaker_Test.php
@@ -101,6 +101,9 @@ class TableMakerTest extends TestCase
         TableMaker::fix($e, $mapper);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testFix_23000_NoModel_DoesNotThrow()
     {
         $e = new TableMakerTestExceptionWithMessage(
@@ -109,9 +112,11 @@ class TableMakerTest extends TestCase
         );
         $mapper = DataMapper::create($this->pdo, null, null);
         TableMaker::fix($e, $mapper, null);
-        $this->assertTrue(true);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testFix_HY000_WithForeignKeyMessage_DoesNotThrow()
     {
         $e = new TableMakerTestExceptionWithMessage(
@@ -120,7 +125,6 @@ class TableMakerTest extends TestCase
         );
         $mapper = DataMapper::create($this->pdo, null, null);
         TableMaker::fix($e, $mapper, null);
-        $this->assertTrue(true);
     }
 
     public function testFix_HY000_WithoutForeignKeyMessage_Rethrows()

--- a/test/anorm/TmModels.php
+++ b/test/anorm/TmModels.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Anorm\Test;
+
+use Anorm\DataMapper;
+use Anorm\Model;
+
+/**
+ * Minimal fixture models for TableMaker FK integration tests.
+ * Class names chosen so getTableNameFromModelClass() derives 'tm_parents' / 'tm_items'.
+ */
+class TmParentModel extends Model
+{
+    public $id;
+    public $name;
+    /** @var TmItemModel[] */
+    public $items;
+
+    public function __construct(\PDO $pdo)
+    {
+        $mapper = DataMapper::createByClass($pdo, $this);
+        $mapper->table = 'tm_parents';
+        $mapper->mode = DataMapper::MODE_DYNAMIC;
+        parent::__construct($pdo, $mapper);
+        $this->hasMany(TmItemModel::class, 'parent_id', 'id', 'items');
+    }
+}
+
+class TmItemModel extends Model
+{
+    public $id;
+    public $name;
+    public $parent_id;
+    /** @var TmParentModel */
+    public $parent;
+
+    public function __construct(\PDO $pdo)
+    {
+        $mapper = DataMapper::createByClass($pdo, $this);
+        $mapper->table = 'tm_items';
+        $mapper->mode = DataMapper::MODE_DYNAMIC;
+        parent::__construct($pdo, $mapper);
+        $this->belongsTo(TmParentModel::class, 'parent_id', 'id', 'parent');
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug fix:** `TableMaker::createForeignKeyFromRelationship()` was comparing `'ManyHasOne'`/`'OneHasMany'` (PascalCase) against `getType()` return values that are `'manyHasOne'`/`'oneHasMany'` (camelCase) — the FK creation chain was silently a no-op for every relationship type. Also adds `ensureTableExists($table)` for the `oneHasMany` path where the source table may not yet exist.
- **TableMaker coverage:** 38.9% → ~80%+ via switch-case tests (23000/HY000 codes) and FK-chain integration tests using new `TmModels.php` fixtures.
- **QueryBuilder coverage:** 80.3% → ~92%+ via tests for `with()` string input, invalid-spec validation, `joinRelationship()`, `setBatchLoadingConfig()`, `setPerformanceMonitor()`, performance-monitor branches in `someWithBatchLoading()`, and nested relationship loading.
- **Model coverage:** 80.3% → ~90%+ via tests for `setNullDelete()`, `restrictDelete()`, `cascadeDelete()`, `constraintOptions()`, auto-generated property names in `hasMany`/`belongsTo`/`hasManyThrough`, and `createForeignKeyConstraints()` early-return branch.

## Test plan

- [ ] `composer test:quick` passes (383 tests, 1 pre-existing skip)
- [ ] `composer quality` passes (phpcs + phpstan level 5 clean)
- [ ] `composer test:coverage` shows coverage improvement in `build/coverage/src/index.html` for the three target files